### PR TITLE
Allow to use a managed connection pool, when deployed in a container

### DIFF
--- a/safeguard-impl/src/main/java/org/apache/safeguard/impl/cdi/FailsafeContainerExecutionManagerProvider.java
+++ b/safeguard-impl/src/main/java/org/apache/safeguard/impl/cdi/FailsafeContainerExecutionManagerProvider.java
@@ -1,0 +1,67 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.safeguard.impl.cdi;
+
+import org.apache.safeguard.api.ExecutionManager;
+import org.apache.safeguard.impl.FailsafeExecutionManager;
+import org.apache.safeguard.impl.bulkhead.BulkheadManagerImpl;
+import org.apache.safeguard.impl.circuitbreaker.FailsafeCircuitBreakerManager;
+import org.apache.safeguard.impl.config.MicroprofileAnnotationMapper;
+import org.apache.safeguard.impl.executionPlans.ExecutionPlanFactory;
+import org.apache.safeguard.impl.executorService.DefaultExecutorServiceProvider;
+import org.apache.safeguard.impl.retry.FailsafeRetryManager;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Alternative;
+import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.Specializes;
+import javax.naming.InitialContext;
+import java.util.concurrent.ScheduledExecutorService;
+
+@Specializes
+@Alternative
+@ApplicationScoped
+public class FailsafeContainerExecutionManagerProvider extends FailsafeExecutionManagerProvider {
+
+    @Produces
+    @ApplicationScoped
+    @Override
+    public ExecutionManager createExecutionManager() throws Exception {
+
+        ScheduledExecutorService executor = new InitialContext().doLookup(
+                System.getProperty("apache.safeguard.executorservice.location",
+                        "java:comp/DefaultManagedScheduledExecutorService"));
+
+        final MicroprofileAnnotationMapper mapper = MicroprofileAnnotationMapper.getInstance();
+        final DefaultExecutorServiceProvider executorServiceProvider = new DefaultExecutorServiceProvider(executor);
+        final BulkheadManagerImpl bulkheadManager = new BulkheadManagerImpl();
+        final FailsafeCircuitBreakerManager circuitBreakerManager = new FailsafeCircuitBreakerManager();
+        final FailsafeRetryManager retryManager = new FailsafeRetryManager();
+
+        return new FailsafeExecutionManager(
+                mapper,
+                bulkheadManager,
+                circuitBreakerManager,
+                retryManager,
+                new ExecutionPlanFactory(circuitBreakerManager, retryManager, bulkheadManager, mapper,
+                        executorServiceProvider),
+                executorServiceProvider);
+    }
+}

--- a/safeguard-impl/src/main/java/org/apache/safeguard/impl/cdi/FailsafeExecutionManagerProvider.java
+++ b/safeguard-impl/src/main/java/org/apache/safeguard/impl/cdi/FailsafeExecutionManagerProvider.java
@@ -23,13 +23,15 @@ import org.apache.safeguard.api.ExecutionManager;
 import org.apache.safeguard.impl.FailsafeExecutionManager;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Default;
 import javax.enterprise.inject.Produces;
 
+@Default
 @ApplicationScoped
 public class FailsafeExecutionManagerProvider {
     @Produces
     @ApplicationScoped
-    public ExecutionManager createExecutionManager() {
+    public ExecutionManager createExecutionManager() throws Exception {
         return new FailsafeExecutionManager();
     }
 }

--- a/safeguard-impl/src/test/java/org/apache/safeguard/retry/test/CDIRetryTest.java
+++ b/safeguard-impl/src/test/java/org/apache/safeguard/retry/test/CDIRetryTest.java
@@ -20,18 +20,10 @@
 package org.apache.safeguard.retry.test;
 
 import org.apache.safeguard.SafeguardCDITest;
-import org.apache.safeguard.impl.cdi.FailsafeExecutionManagerProvider;
-import org.apache.safeguard.impl.cdi.SafeguardExtension;
-import org.apache.safeguard.impl.cdi.SafeguardInterceptor;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.testng.annotations.Test;
 
-import javax.enterprise.inject.spi.Extension;
 import javax.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
Safegard creates an unmanaged connection pool to handle the bulckhead and async operations. When deployed in a container, that pool has to be managed by the container. This PR allows to retrieve that managed pool, if available.